### PR TITLE
Prepare the plug-in to upcoming support of TCP connections with Cannelloni and improve its stability

### DIFF
--- a/CannelloniCanBackend.cpp
+++ b/CannelloniCanBackend.cpp
@@ -73,10 +73,12 @@ canfd_frame convert(const QCanBusFrame& qtFrame)
 }
 } // namespace
 
-CannelloniCanBackend::CannelloniCanBackend(quint16 localPort,
+CannelloniCanBackend::CannelloniCanBackend(const QHostAddress& localAddr,
+                                           quint16 localPort,
                                            const QHostAddress& remoteAddr,
                                            quint16 remotePort)
-    : localPort_(localPort), remoteAddr_(remoteAddr), remotePort_(remotePort),
+    : localAddr_(localAddr), localPort_(localPort),
+      remoteAddr_(remoteAddr), remotePort_(remotePort),
       timerId_(0)
 {
 }
@@ -95,7 +97,7 @@ QString CannelloniCanBackend::interpretErrorFrame(const QCanBusFrame&)
 bool CannelloniCanBackend::open()
 {
     Q_ASSERT(!sock_.isOpen());
-    if (!sock_.bind(QHostAddress::LocalHost, localPort_))
+    if (!sock_.bind(localAddr_, localPort_))
     {
         setState(QCanBusDevice::UnconnectedState);
         return false;

--- a/CannelloniCanBackend.h
+++ b/CannelloniCanBackend.h
@@ -8,8 +8,8 @@ class CannelloniCanBackend : public QCanBusDevice
 {
     Q_OBJECT
 public:
-    CannelloniCanBackend(quint16 localPort, const QHostAddress& remoteAddr,
-                         quint16 remotePort);
+    CannelloniCanBackend(const QHostAddress& localAddr, quint16 localPort,
+                         const QHostAddress& remoteAddr, quint16 remotePort);
 
     bool writeFrame(const QCanBusFrame& frame) override;
     QString interpretErrorFrame(const QCanBusFrame& errorFrame) override;
@@ -20,6 +20,7 @@ protected:
     void timerEvent(QTimerEvent*) override;
 
 private:
+    QHostAddress localAddr_;
     quint16 localPort_;
     QHostAddress remoteAddr_;
     quint16 remotePort_;

--- a/QtCannelloniCanBusPlugin.cpp
+++ b/QtCannelloniCanBusPlugin.cpp
@@ -20,14 +20,20 @@ public:
         auto tokens = interfaceName.split(QChar(','));
         if (tokens.size() < 2 || tokens.size() > 4)
         {
-            *errorMessage = "Invalid interface name format";
+            if (errorMessage)
+            {
+                *errorMessage = "Invalid interface name format";
+            }
             return nullptr;
         }
         qsizetype tokenIndex = 0;
         QHostAddress localAddr(QHostAddress::AnyIPv4);
         if (tokens.size() > 3 && !localAddr.setAddress(tokens[tokenIndex++]))
         {
-            *errorMessage = "Invalid local address format";
+            if (errorMessage)
+            {
+                *errorMessage = "Invalid local address format";
+            }
             return nullptr;
         }
         bool ok;
@@ -37,20 +43,29 @@ public:
             localPort = tokens[tokenIndex++].toUInt(&ok);
             if (!ok || localPort > quint16max)
             {
-                *errorMessage = "Invalid local port format";
+                if (errorMessage)
+                {
+                    *errorMessage = "Invalid local port format";
+                }
                 return nullptr;
             }
         }
         QHostAddress remoteAddr(tokens[tokenIndex++]);
         if (remoteAddr.isNull())
         {
-            *errorMessage = "Invalid remote address format";
+            if (errorMessage)
+            {
+                *errorMessage = "Invalid remote address format";
+            }
             return nullptr;
         }
         auto remotePort = tokens[tokenIndex++].toUInt(&ok);
         if (!ok || remotePort > quint16max)
         {
-            *errorMessage = "Invalid remote port format";
+            if (errorMessage)
+            {
+                *errorMessage = "Invalid remote port format";
+            }
             return nullptr;
         }
         return new CannelloniCanBackend(localAddr, localPort, remoteAddr, remotePort);


### PR DESCRIPTION
This pull request prepares the plug-in code base to the planned support of sending and receiving CAN frames over TCP connections – a feature that was implemented in Cannelloni v1.1.0. It also includes:
* a configuration enhancement aimed at that upcoming support of TCP and at improving the support of UDP outside of the localhost interface;
* a stability fix for the plug-in code integrating with the QT framework.

Here is a list of the change-sets: 
* Bump cannelloni to v1.1.0;
* Default local address to "0.0.0.0" and make it configurable;
* Prevent CANdevStudio crashes on bad interface parameter strings.