### PR TITLE
chore: added compatibility with QCanBusFactoryV2

### DIFF
--- a/QtCannelloniCanBusPlugin.cpp
+++ b/QtCannelloniCanBusPlugin.cpp
@@ -12,6 +12,12 @@ class QtCannelloniCanBusPlugin : public QObject, public QCanBusFactory
     Q_INTERFACES(QCanBusFactory)
 
 public:
+    QList<QCanBusDeviceInfo> availableDevices(QString *errorMessage) const
+    {
+        *errorMessage = "Devices cannot be enumerated for 'cannelloni' backend";
+        return QList<QCanBusDeviceInfo>();
+    }
+
     QCanBusDevice* createDevice(const QString& interfaceName,
                                 QString* errorMessage) const override
     {


### PR DESCRIPTION
The pure virtual function 'QList<QCanBusDeviceInfo> QCanBusFactory::availableDevices(QString *errorMessage)' have been implemented in order to adhere to QCanBusFactoryV2